### PR TITLE
This code makes the c_globals constructor private, so the only way to create an instance is by calling the get_instance() function. The get_instance()

### DIFF
--- a/Source/globals.h
+++ b/Source/globals.h
@@ -1,7 +1,18 @@
 #pragma
 
-class c_globals
-{
+class c_globals {
+private:
+    bool active;
+    c_globals() : active(true) {}
 public:
-	bool active = true;
-} globals;
+    static c_globals& get_instance() {
+        static c_globals instance;
+        return instance;
+    }
+    bool is_active() const {
+        return active;
+    }
+    void set_active(bool value) {
+        active = value;
+    }
+};


### PR DESCRIPTION
`c_globals` class, ensuring that only one instance is ever created. `The is_active() and set_active()` functions are provided to get and set the active variable, respectively. To access the active variable, you would call the functions like this:

```cpp
c_globals& globals = c_globals::get_instance();
bool active = globals.is_active();
globals.set_active(false);
```
